### PR TITLE
Validate.string is erroneously checking non-empty

### DIFF
--- a/src/Form/Validate.elm
+++ b/src/Form/Validate.elm
@@ -232,9 +232,6 @@ string : Validation e String
 string v =
   case Field.asString v of
     Just s ->
-      if String.isEmpty s then
-        Err Empty
-      else
         Ok s
 
     Nothing ->


### PR DESCRIPTION
there is a separate combinator for that
