### PR TITLE
Fix TextArea Bug

### DIFF
--- a/src/Form/Input.elm
+++ b/src/Form/Input.elm
@@ -65,15 +65,14 @@ textArea : Input e String
 textArea state attrs =
   let
     formAttrs =
-      [ onInput (Textarea >> (Input state.path))
+      [ value (state.value ?= "")
+      , onInput (Textarea >> (Input state.path))
       , onFocus (Focus state.path)
       , onBlur (Blur state.path)
       ]
 
-    value =
-      state.value ?= ""
   in
-    Html.textarea (formAttrs ++ attrs) [ text value ]
+    Html.textarea (formAttrs ++ attrs) []
 
 
 {-| Select input.


### PR DESCRIPTION
If the user edit the textarea once, any further javascript update is not computed, as seen here https://github.com/evancz/elm-html/issues/36. Evan's suggestion is to use the value attribute instead of innerHtml. I can confirm this works in Chrome 51, Firefox 46,  Edge 25 (all Windows 10).
