### PR TITLE
Fix typo and reuse Maybe.andThen logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ app = Html.program
 
  * For rendering, `Form.getFieldAsString`/`Bool` provides a `FieldState` record with all required fields (see package doc).
 
- * For event handling, see all field related actions in `Form.Action` type.
+ * For event handling, see all field related messages in `Form.Msg` type.
 
 Overall, having a look at current [helpers source code](https://github.com/etaque/elm-simple-form/blob/master/src/Form/Input.elm) should give you a good idea of the thing.
 
@@ -165,7 +165,7 @@ validate =
 * View:
 
 ```elm
-Input.textInput (Form.getFieldAsString "options.foo" form) formAddress []
+Input.textInput (Form.getFieldAsString "options.foo" form) []
 ```
 
 ### Initial values and reset
@@ -214,6 +214,6 @@ validate =
 
 ### Async validation
 
-This package doesn't provide anything special for async validation, but doesn't prevent you to do that neither. As field values are accessible from `update` with `Form.getStringAt/getBoolAt`, you can proceed them as you need, trigger effects like an HTTP request, and then add any errors to the view by yourself.
+This package doesn't provide anything special for async validation, but doesn't prevent you to do that neither. As field values are accessible from `update` with `Form.getStringAt/getBoolAt`, you can process them as you need, trigger effects like an HTTP request, and then add any errors to the view by yourself.
 
 Another way would be to enable dynamic validation reload, to make it dependant of an effect, as it's part of the form state. Please ping me if this feature would be useful to you.

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -233,12 +233,7 @@ getFieldAt : String -> Form e o -> Maybe Field
 getFieldAt qualifiedName (F model) =
   let
     walkPath name maybeField =
-      case maybeField of
-        Just field ->
-          Field.at name field
-
-        Nothing ->
-          Nothing
+      maybeField `Maybe.andThen` Field.at name
   in
     List.foldl walkPath (Just model.fields) (String.split "." qualifiedName)
 
@@ -312,18 +307,14 @@ getErrorAt qualifiedName (F model) =
   let
     walkPath path maybeNode =
       case path of
-        name :: rest ->
-          case maybeNode of
-            Just error ->
-              case error of
-                GroupErrors _ ->
-                  walkPath rest (Error.getAt name error)
+        name :: rest -> maybeNode `Maybe.andThen`
+          \error ->
+            case error of
+              GroupErrors _ ->
+                walkPath rest (Error.getAt name error)
 
-                _ ->
-                  Just error
-
-            Nothing ->
-              Nothing
+              _ ->
+                Just error
 
         [] ->
           maybeNode

--- a/src/Form/Input.elm
+++ b/src/Form/Input.elm
@@ -18,7 +18,7 @@ import Form exposing (Form, Msg, FieldState, Msg (Input, Focus, Blur))
 import Form.Field exposing (Field(..))
 
 
-{-| An input render Html from a field state, a form and address for messages.
+{-| An input renders Html from a field state and list of additional attributes.
 All input functions using this type alias are pre-wired with event handlers.
 -}
 type alias Input e a =


### PR DESCRIPTION
Reducing some boilerplate by reusing `Maybe.andThen`

Feel free to close if you don't like it, but I find it a bit more readable.
Also corrected one comment which didn't correspond to the code.

Anyway I really like this library :)
