### PR TITLE
Proposal: Replace input's value for defaultValue

### DIFF
--- a/src/Form/Input.elm
+++ b/src/Form/Input.elm
@@ -36,7 +36,7 @@ baseInput t toField state attrs =
   let
     formAttrs =
       [ type' t
-      , value (state.value ?= "")
+      , defaultValue (state.value ?= "")
       , onInput (toField >> (Input state.path))
       , onFocus (Focus state.path)
       , onBlur (Blur state.path)
@@ -65,7 +65,7 @@ textArea : Input e String
 textArea state attrs =
   let
     formAttrs =
-      [ value (state.value ?= "")
+      [ defaultValue (state.value ?= "")
       , onInput (Textarea >> (Input state.path))
       , onFocus (Focus state.path)
       , onBlur (Blur state.path)


### PR DESCRIPTION
# Problem

If you type too fast in an input or text area, the cursor will jump to the end and make typos, as seen [here](https://github.com/evancz/elm-html/pull/81#issuecomment-145676200).
# Solution

As suggested by Kris and Richard, [here](https://github.com/evancz/elm-html/pull/81#issue-109646461) and [here](https://gist.github.com/rtfeldman/5f015adbdfbba541c7e7e1409b6efeef#gistcomment-1831492), make use of the [defaultValue](http://package.elm-lang.org/packages/elm-lang/html/1.1.0/Html-Attributes#defaultValue) attribute instead value solves the problem and, so far I tested, has no side effects (we still get the input event and can alter the input visual text programatically).
