### PR TITLE
Make Validate.formatError more general

### DIFF
--- a/src/Form/Validate.elm
+++ b/src/Form/Validate.elm
@@ -86,7 +86,7 @@ defaultValue a validation field =
 
 {-| Call Result.formatError on validation result.
 -}
-formatError : (Error e -> Error e) -> Validation e a -> Validation e a
+formatError : (Error e1 -> Error e2) -> Validation e1 a -> Validation e2 a
 formatError f validation =
   \field -> Result.formatError f (validation field)
 


### PR DESCRIPTION
Generalising the type signature of `Validate.formatError`.

Sorry, I should have noticed this when I submitted #41.  But I only spotted it now when I pulled the latest `simple-form` and was surprised to find that I couldn't slot in `Validate.formatError` where I had previously been using a home-grown version.

By the way, my main use case for this is another utility that I've written a couple of times now:

``` elm
withError : CustomError -> Validation e1 a -> Validation CustomError a
withError = formatError << always << customError

```

which I find useful whenever I have some general error coming out of the validation and I want to make it more specific to my business logic.  Here's an example:

``` elm
(get "customerId" (V.int
       `andThen` minInt 1
       `andThen` maxInt 9999
       |> withError InvalidIdentity))
```

Would you have any interest in a pull request submitting `withError`?
