### PR TITLE
Fix example's Reset action

### DIFF
--- a/example/src/View/Bootstrap.elm
+++ b/example/src/View/Bootstrap.elm
@@ -45,14 +45,22 @@ textGroup : GroupBuilder String
 textGroup label' state =
     formGroup label'
         state.liveError
-        [ Input.textInput state [ class "form-control" ] ]
+        [ Input.textInput state
+            [ class "form-control"
+            , value (Maybe.withDefault "" state.value)
+            ]
+        ]
 
 
 textAreaGroup : GroupBuilder String
 textAreaGroup label' state =
     formGroup label'
         state.liveError
-        [ Input.textArea state [ class "form-control" ] ]
+        [ Input.textArea state
+            [ class "form-control"
+            , value (Maybe.withDefault "" state.value)
+            ]
+        ]
 
 
 checkboxGroup : GroupBuilder Bool


### PR DESCRIPTION
When using defaultValue, to have control over the text elements value, we must set the `value` attribute to reflect the model state.
