### PR TITLE
Dynamic fields list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ os:
 
 env:
   matrix:
-    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.17.0 TARGET_NODE_VERSION=4.0
+    - ELM_VERSION=0.18.0 TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.18.0 TARGET_NODE_VERSION=4.0
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ HTML live forms builders and validation for Elm. [![Build Status](https://travis
 * Validation API similar to `Json.Decode` with the standard `map`, `andThen`, etc: you either get the desired output value or all field errors
 * HTML inputs helpers with pre-wired handlers for live validation
 * Suite of basic validations, with a way to add your own
-* Unlimited fields! See `apply` function, similar to Json.Extra
+* Unlimited fields, see `andMap` function (as in `Json.Extra`)
 * Nested fields (`foo.bar.baz`) and lists (`todos.1.checked`) enabling rich form build
 
 [See complete example here](http://etaque.github.io/elm-simple-form/example/) ([source code](https://github.com/etaque/elm-simple-form/tree/master/example)).
@@ -22,7 +22,6 @@ HTML live forms builders and validation for Elm. [![Build Status](https://travis
 ```elm
 module Main exposing (..)
 
-import Html.App as Html
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -34,92 +33,94 @@ import Form.Input as Input
 -- your expected form output
 
 type alias Foo =
-  { bar : String
-  , baz : Bool
-  }
+    { bar : String
+    , baz : Bool
+    }
 
 
 -- Add form to your model and msgs
 
 type alias Model =
-  { form : Form () Foo }
+    { form : Form () Foo }
 
-type Msg =
-  NoOp | FormMsg Form.Msg
+type Msg
+    = NoOp
+    | FormMsg Form.Msg
 
 
 -- Setup form validation
 
-init : (Model, Cmd Msg)
+init : ( Model, Cmd Msg )
 init =
-  ({ form = Form.initial [] validate }, Cmd.none)
-
+    ( { form = Form.initialFields [] validate }, Cmd.none )
 
 validate : Validation () Foo
 validate =
-  form2 Foo
-    (get "bar" email)
-    (get "baz" bool)
+    map2 Foo
+        (field "bar" email)
+        (field "baz" bool)
 
 
 -- Forward form msgs to Form.update
 
-update : Msg -> Model -> (Model, Cmd Msg)
-update msg ({form} as model) =
-  case msg of
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg ({ form } as model) =
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
 
-    NoOp ->
-      (model, Cmd.none)
-
-    FormMsg formMsg ->
-      ({ model | form = Form.update formMsg form}, Cmd.none)
+        FormMsg formMsg ->
+            ( { model | form = Form.update formMsg form }, Cmd.none )
 
 
 -- Render form with Input helpers
 
 view : Model -> Html Msg
-view {form} =
-  Html.map FormMsg (formView form)
+view { form } =
+    Html.map FormMsg (formView form)
 
 formView : Form () Foo -> Html Form.Msg
 formView form =
-  let
-    -- error presenter
-    errorFor field =
-      case field.liveError of
-        Just error ->
-          -- replace toString with your own translations
-          div [ class "error" ] [ text (toString error) ]
-        Nothing ->
-          text ""
+    let
+        -- error presenter
+        errorFor field =
+            case field.liveError of
+                Just error ->
+                    -- replace toString with your own translations
+                    div [ class "error" ] [ text (toString error) ]
 
-    -- fields states
-    bar = Form.getFieldAsString "bar" form
-    baz = Form.getFieldAsBool "baz" form
-  in
-    div []
-      [ label [] [ text "Bar" ]
-      , Input.textInput bar []
-      , errorFor bar
+                Nothing ->
+                    text ""
 
-      , label []
-          [ Input.checkboxInput baz []
-          , text "Baz"
-          ]
-      , errorFor baz
+        -- fields states
+        bar =
+            Form.getFieldAsString "bar" form
 
-      , button
-          [ onClick Form.Submit ]
-          [ text "Submit" ]
-      ]
+        baz =
+            Form.getFieldAsBool "baz" form
+    in
+        div []
+            [ label [] [ text "Bar" ]
+            , Input.textInput bar []
+            , errorFor bar
+            , label []
+                [ Input.checkboxInput baz []
+                , text "Baz"
+                ]
+            , errorFor baz
+            , button
+                [ onClick Form.Submit ]
+                [ text "Submit" ]
+            ]
 
 
-app = Html.program
-  { init = init
-  , update = update
-  , view = view
-  , subscriptions = \_ -> Sub.none
-  }
+app =
+    Html.program
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = \_ -> Sub.none
+        }
 ```
 
 
@@ -139,8 +140,8 @@ Similar to what Json.Extra provides. Use `Form.apply`, or the `|:` infix version
 
 ```elm
 Form.succeed Player
-  `apply` (get "email" (string `andThen` email))
-  `apply` (get "power" int)
+    |> andMap (field "email" (string |> andThen email))
+    |> andMap (field "power" int)
 ```
 
 ### Nested records
@@ -149,15 +150,15 @@ Form.succeed Player
 
 ```elm
 validate =
-  form2 Player
-    (get "email" (string `andThen` email))
-    (get "power" (int `andThen` (minInt 0)))
-    (get "options"
-      (form2 Options
-        (get "foo" string)
-        (get "bar" string)
-      )
-    )
+    map2 Player
+        (field "email" (string |> andThen email))
+        (field "power" (int |> andThen (minInt 0)))
+        (field "options"
+            (map2 Options
+                (field "foo" string)
+                (field "bar" string)
+            )
+        )
 ```
 
 * View:
@@ -166,6 +167,57 @@ validate =
 Input.textInput (Form.getFieldAsString "options.foo" form) []
 ```
 
+### Dynamic lists
+
+```elm
+-- model
+type alias TodoList =
+    { title : String
+    , items : List String
+    }
+
+-- validation
+validate : Validation () Issue
+validate =
+    map2 TodoList
+        (field "title" string)
+        (field "items" (list string))
+
+-- view
+formView : Form () Issue -> Html Form.Msg
+formView form =
+    div
+        [ class "todo-list" ]
+        [ Input.textInput
+            (Form.getFieldAsString "title" form)
+            [ placeholder "Title" ]
+        , div [ class "items" ] <|
+            List.map
+                (itemView form)
+                (Form.getListIndexes "items" form)
+        , button
+            [ class "add"
+            , onClick (Form.Append "items")
+            ]
+            [ text "Add" ]
+        ]
+
+itemView : Form () Issue -> Int -> Html Form.Msg
+itemView form i =
+    div
+        [ class "item" ]
+        [ Input.textInput
+            (Form.getFieldAsString ("items." ++ (toString i)) form)
+            []
+        , a
+            [ class "remove"
+            , onClick (Form.RemoveItem "items" i)
+            ]
+            [ text "Remove" ]
+        ]
+```
+
+
 ### Initial values and reset
 
 * At form initialization:
@@ -173,19 +225,22 @@ Input.textInput (Form.getFieldAsString "options.foo" form) []
 ```elm
 import Form.Field as Field
 
-initialFields : List (String, Field)
+
+initialFields : List ( String, Field )
 initialFields =
-  [ ("power", Field.Text "10")
-  , ("options", Field.group
-      [ ("foo", Field.Text "blah")
-      , ("bar", Field.Text "meh")
-      ]
-    )
-  ]
+    [ ( "power", Field.string "10" )
+    , ( "options"
+      , Field.group
+            [ ( "foo", Field.string "blah" )
+            , ( "bar", Field.string "meh" )
+            ]
+      )
+    ]
+
 
 initialForm : Form
 initialForm =
-  Form.initial initialFields validate
+    Form.initial initialFields validate
 ```
 
 See `Form.Field` type for more options.
@@ -208,7 +263,7 @@ type LocalError = Fatal | NotSoBad
 
 validate : Validate LocalError Foo
 validate =
-  (get "foo" (string |> customError Fatal))
+    (field "foo" (string |> customError Fatal))
 
 -- creates `Form.Error.CustomError Fatal`
 ```

--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ HTML live forms builders and validation for Elm. [![Build Status](https://travis
 * HTML inputs helpers with pre-wired handlers for live validation
 * Suite of basic validations, with a way to add your own
 * Unlimited fields! See `apply` function, similar to Json.Extra
-* Nested fields for record composition (`foo.bar.baz`)
+* Nested fields (`foo.bar.baz`) and lists (`todos.1.checked`) enabling rich form build
 
 [See complete example here](http://etaque.github.io/elm-simple-form/example/) ([source code](https://github.com/etaque/elm-simple-form/tree/master/example)).
-
-Infix operators have been splitted to a [dedicated package](https://github.com/etaque/elm-simple-form-infix).
 
 
 ## Basic usage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Elm SimpleForm
+# Elm Form
 
-HTML live forms builders and validation for Elm. [![Build Status](https://travis-ci.org/etaque/elm-simple-form.svg?branch=master)](https://travis-ci.org/etaque/elm-simple-form)
+HTML live forms builders and validation for Elm. [![Build Status](https://travis-ci.org/etaque/elm-form.svg?branch=master)](https://travis-ci.org/etaque/elm-form)
 
-    elm package install etaque/elm-simple-form
+    elm package install etaque/elm-form
 
 
 ## Features
@@ -13,7 +13,7 @@ HTML live forms builders and validation for Elm. [![Build Status](https://travis
 * Unlimited fields, see `andMap` function (as in `Json.Extra`)
 * Nested fields (`foo.bar.baz`) and lists (`todos.1.checked`) enabling rich form build
 
-[See complete example here](http://etaque.github.io/elm-simple-form/example/) ([source code](https://github.com/etaque/elm-simple-form/tree/master/example)).
+[See complete example here](http://etaque.github.io/elm-form/example/) ([source code](https://github.com/etaque/elm-form/tree/master/example)).
 
 
 ## Basic usage
@@ -132,11 +132,11 @@ app =
 
  * For event handling, see all field related messages in `Form.Msg` type.
 
-Overall, having a look at current [helpers source code](https://github.com/etaque/elm-simple-form/blob/master/src/Form/Input.elm) should give you a good idea of the thing.
+Overall, having a look at current [helpers source code](https://github.com/etaque/elm-form/blob/master/src/Form/Input.elm) should give you a good idea of the thing.
 
 ### Incremental validation
 
-Similar to what Json.Extra provides. Use `Form.apply`, or the `|:` infix version from [infix package](https://github.com/etaque/elm-simple-form-infix):
+Similar to what Json.Extra provides. Use `Form.apply`, or the `|:` infix version from [infix package](https://github.com/etaque/elm-form-infix):
 
 ```elm
 Form.succeed Player
@@ -251,7 +251,7 @@ See `Form.Field` type for more options.
 button [ onClick (Form.Reset initialFields) ] [ text "Reset" ]
 ```
 
-*Note:* To have programmatically control over any `input[type=text]`/`textarea` value, like reseting or changing the value, you must set the `value` attribute with `Maybe.withDefault "" state.value`, as seen [here](https://github.com/etaque/elm-simple-form/pull/57/files#diff-bfb877e82b2c89b329fcda943a258611R50). There's a downside of doing this: if the user types too fast, the caret can go crazy.
+*Note:* To have programmatically control over any `input[type=text]`/`textarea` value, like reseting or changing the value, you must set the `value` attribute with `Maybe.withDefault "" state.value`, as seen [here](https://github.com/etaque/elm-form/pull/57/files#diff-bfb877e82b2c89b329fcda943a258611R50). There's a downside of doing this: if the user types too fast, the caret can go crazy.
 
 More info: https://github.com/evancz/elm-html/pull/81#issuecomment-145676200
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "5.0.1",
-    "summary": "Simple forms made easy, for Elm",
-    "repository": "https://github.com/etaque/elm-simple-form.git",
+    "summary": "Live validation of form inputs in Elm",
+    "repository": "https://github.com/etaque/elm-form.git",
     "license": "BSD3",
     "source-directories": [
         "src/"

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,11 +11,12 @@
         "Form.Error",
         "Form.Validate",
         "Form.Field",
-        "Form.Input"
+        "Form.Input",
+        "Form.Init"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
-    "summary": "Example for elm-simple-form",
-    "repository": "https://github.com/etaque/elm-simple-form.git",
+    "summary": "Example for elm-form",
+    "repository": "https://github.com/etaque/elm-form.git",
     "license": "BSD3",
     "source-directories": [
         "src/",

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -9,9 +9,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "etaque/elm-response": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "etaque/elm-response": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (..)
 
-import Html.App as Html
+import Html
 import View exposing (view)
 import Update exposing (init, update)
 

--- a/example/src/Model.elm
+++ b/example/src/Model.elm
@@ -1,7 +1,7 @@
 module Model exposing (..)
 
 import Form exposing (Form)
-import Form.Field as Field exposing (Field, field, group)
+import Form.Field as Field exposing (Field)
 import Form.Validate as Validate exposing (..)
 
 
@@ -54,15 +54,19 @@ type alias Todo =
 
 initialFields : List ( String, Field )
 initialFields =
-    [ field "name" (Field.Text "hey")
-    , group "profile"
-        [ field "age" (Field.Text "33") ]
-    , Field.list "todos"
-        [ Field.listGroup
-            [ field "done" (Field.Check True)
-            , field "label" (Field.Text "Remember the milk")
+    [ ( "name", Field.string "hey" )
+    , ( "profile"
+      , Field.group
+            [ ( "age", Field.string "33" ) ]
+      )
+    , ( "todos"
+      , Field.list
+            [ Field.group
+                [ ( "done", Field.bool True )
+                , ( "label", Field.string "Remember the milk" )
+                ]
             ]
-        ]
+      )
     ]
 
 
@@ -78,30 +82,30 @@ superpowers =
 
 validate : Validation CustomError User
 validate =
-    form5
+    map5
         User
-        (get "name" (string `andThen` nonEmpty))
-        (get "email" (email `andThen` (asyncCheck True)))
-        (get "admin" (bool |> defaultValue False))
-        (get "profile" validateProfile)
-        (get "todos" (list validateTodo))
+        (field "name" (string |> andThen nonEmpty))
+        (field "email" (email |> andThen (asyncCheck True)))
+        (field "admin" (bool |> defaultValue False))
+        (field "profile" validateProfile)
+        (field "todos" (list validateTodo))
 
 
 validateProfile : Validation CustomError Profile
 validateProfile =
     succeed Profile
-        `apply`
-            (get "website"
+        |> andMap
+            (field "website"
                 (oneOf
                     [ emptyString |> map (\_ -> Nothing)
                     , url |> map Just
                     ]
                 )
             )
-        `apply` (get "role" (string `andThen` (includedIn roles)))
-        `apply` (get "superpower" validateSuperpower)
-        `apply` (get "age" naturalInt)
-        `apply` (get "bio" (string |> defaultValue ""))
+        |> andMap (field "role" (string |> andThen (includedIn roles)))
+        |> andMap (field "superpower" validateSuperpower)
+        |> andMap (field "age" naturalInt)
+        |> andMap (field "bio" (string |> defaultValue ""))
 
 
 validateSuperpower : Validation CustomError Superpower
@@ -123,9 +127,9 @@ validateSuperpower =
 
 validateTodo : Validation CustomError Todo
 validateTodo =
-    form2 Todo
-        (get "done" bool)
-        (get "label" string)
+    map2 Todo
+        (field "done" bool)
+        (field "label" string)
 
 
 

--- a/example/src/Model.elm
+++ b/example/src/Model.elm
@@ -28,6 +28,7 @@ type alias User =
     , email : String
     , admin : Bool
     , profile : Profile
+    , links : List Link
     }
 
 
@@ -43,6 +44,12 @@ type alias Profile =
 type Superpower
     = Flying
     | Invisible
+
+
+type alias Link =
+    { name : String
+    , url : String
+    }
 
 
 initialFields : List ( String, Field.Field )
@@ -74,12 +81,13 @@ infixl 7 :=
 
 validate : Validation CustomError User
 validate =
-    form4
+    form5
         User
         ("name" := string `andThen` nonEmpty)
         ("email" := email `andThen` (asyncCheck True))
         ("admin" := bool |> defaultValue False)
         ("profile" := validateProfile)
+        ("links" := list validateLink)
 
 
 validateProfile : Validation CustomError Profile
@@ -112,6 +120,13 @@ validateSuperpower =
                 _ ->
                     Err (customError InvalidSuperpower)
         )
+
+
+validateLink : Validation CustomError Link
+validateLink =
+    form2 Link
+        (get "name" string)
+        (get "url" url)
 
 
 

--- a/example/src/Model.elm
+++ b/example/src/Model.elm
@@ -28,7 +28,7 @@ type alias User =
     , email : String
     , admin : Bool
     , profile : Profile
-    , links : List Link
+    , todos : List Todo
     }
 
 
@@ -46,9 +46,9 @@ type Superpower
     | Invisible
 
 
-type alias Link =
-    { name : String
-    , url : String
+type alias Todo =
+    { done : Bool
+    , label : String
     }
 
 
@@ -57,6 +57,12 @@ initialFields =
     [ field "name" (Field.Text "hey")
     , group "profile"
         [ field "age" (Field.Text "33") ]
+    , Field.list "todos"
+        [ Field.listGroup
+            [ field "done" (Field.Check True)
+            , field "label" (Field.Text "Remember the milk")
+            ]
+        ]
     ]
 
 
@@ -78,7 +84,7 @@ validate =
         (get "email" (email `andThen` (asyncCheck True)))
         (get "admin" (bool |> defaultValue False))
         (get "profile" validateProfile)
-        (get "links" (list validateLink))
+        (get "todos" (list validateTodo))
 
 
 validateProfile : Validation CustomError Profile
@@ -115,11 +121,11 @@ validateSuperpower =
         )
 
 
-validateLink : Validation CustomError Link
-validateLink =
-    form2 Link
-        (get "name" (string `andThen` (minLength 3)))
-        (get "url" url)
+validateTodo : Validation CustomError Todo
+validateTodo =
+    form2 Todo
+        (get "done" bool)
+        (get "label" string)
 
 
 

--- a/example/src/Model.elm
+++ b/example/src/Model.elm
@@ -1,7 +1,7 @@
 module Model exposing (..)
 
 import Form exposing (Form)
-import Form.Field as Field
+import Form.Field as Field exposing (Field, field, group)
 import Form.Validate as Validate exposing (..)
 
 
@@ -52,9 +52,11 @@ type alias Link =
     }
 
 
-initialFields : List ( String, Field.Field )
+initialFields : List ( String, Field )
 initialFields =
-    [ ( "name", Field.Text "hey" )
+    [ field "name" (Field.Text "hey")
+    , group "profile"
+        [ field "age" (Field.Text "33") ]
     ]
 
 

--- a/example/src/Model.elm
+++ b/example/src/Model.elm
@@ -70,41 +70,32 @@ superpowers =
     [ "flying", "invisible" ]
 
 
-{-| Infix operators. See elm-simple-form-infix for a packaged version.
--}
-(:=) =
-    Validate.get
-infixl 7 :=
-
-
-(|:) =
-    Validate.apply
-
-
 validate : Validation CustomError User
 validate =
     form5
         User
-        ("name" := string `andThen` nonEmpty)
-        ("email" := email `andThen` (asyncCheck True))
-        ("admin" := bool |> defaultValue False)
-        ("profile" := validateProfile)
-        ("links" := list validateLink)
+        (get "name" (string `andThen` nonEmpty))
+        (get "email" (email `andThen` (asyncCheck True)))
+        (get "admin" (bool |> defaultValue False))
+        (get "profile" validateProfile)
+        (get "links" (list validateLink))
 
 
 validateProfile : Validation CustomError Profile
 validateProfile =
     succeed Profile
-        |: ("website"
-                := oneOf
+        `apply`
+            (get "website"
+                (oneOf
                     [ emptyString |> map (\_ -> Nothing)
                     , url |> map Just
                     ]
-           )
-        |: ("role" := (string `andThen` (includedIn roles)))
-        |: ("superpower" := validateSuperpower)
-        |: ("age" := naturalInt)
-        |: ("bio" := string |> defaultValue "")
+                )
+            )
+        `apply` (get "role" (string `andThen` (includedIn roles)))
+        `apply` (get "superpower" validateSuperpower)
+        `apply` (get "age" naturalInt)
+        `apply` (get "bio" (string |> defaultValue ""))
 
 
 validateSuperpower : Validation CustomError Superpower
@@ -127,7 +118,7 @@ validateSuperpower =
 validateLink : Validation CustomError Link
 validateLink =
     form2 Link
-        (get "name" string)
+        (get "name" (string `andThen` (minLength 3)))
         (get "url" url)
 
 

--- a/example/src/View.elm
+++ b/example/src/View.elm
@@ -6,6 +6,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Form exposing (Form)
+import Form.Input as Input
 import Model exposing (..)
 import View.Bootstrap exposing (..)
 
@@ -56,6 +57,7 @@ formView form =
                 (Form.getFieldAsString "profile.age" form)
             , textAreaGroup "Bio"
                 (Form.getFieldAsString "profile.bio" form)
+            , linksView form
             , formActions
                 [ button
                     [ onClick Form.Submit
@@ -70,3 +72,26 @@ formView form =
                     [ text "Reset" ]
                 ]
             ]
+
+
+linksView : Form CustomError User -> Html Form.Msg
+linksView form =
+    let
+        linkView i =
+            div
+                [ class "row link" ]
+                [ col' 3 [ text "Link" ]
+                , Input.textInput
+                    (Form.getFieldAsString ("links." ++ (toString i) ++ ".name") form)
+                    [ placeholder "Name" ]
+                , textGroup
+                    "URL"
+                    (Form.getFieldAsString ("links." ++ (toString i) ++ ".url") form)
+                , button [ onClick (Form.RemoveItem "links" i) ] [ text "Remove" ]
+                ]
+    in
+        div
+            [ class "links" ]
+        <|
+            (List.map linkView (Form.getListIndexes "links" form))
+                ++ [ button [ onClick (Form.Append "links") ] [ text "Add link" ] ]

--- a/example/src/View.elm
+++ b/example/src/View.elm
@@ -39,25 +39,25 @@ formView form =
             , style [ ( "margin", "50px auto" ), ( "width", "600px" ) ]
             ]
             [ legend [] [ text "Elm Simple Form example" ]
-            , textGroup "Name"
+            , textGroup (text "Name")
                 (Form.getFieldAsString "name" form)
-            , textGroup "Email address"
+            , textGroup (text "Email address")
                 (Form.getFieldAsString "email" form)
-            , checkboxGroup "Administrator"
+            , checkboxGroup (text "Administrator")
                 (Form.getFieldAsBool "admin" form)
-            , textGroup "Website"
+            , textGroup (text "Website")
                 (Form.getFieldAsString "profile.website" form)
             , selectGroup roleOptions
-                "Role"
+                (text "Role")
                 (Form.getFieldAsString "profile.role" form)
             , radioGroup superpowerOptions
-                "Superpower"
+                (text "Superpower")
                 (Form.getFieldAsString "profile.superpower" form)
-            , textGroup "Age"
+            , textGroup (text "Age")
                 (Form.getFieldAsString "profile.age" form)
-            , textAreaGroup "Bio"
+            , textAreaGroup (text "Bio")
                 (Form.getFieldAsString "profile.bio" form)
-            , linksView form
+            , todosView form
             , formActions
                 [ button
                     [ onClick Form.Submit
@@ -74,24 +74,48 @@ formView form =
             ]
 
 
-linksView : Form CustomError User -> Html Form.Msg
-linksView form =
+todosView : Form CustomError User -> Html Form.Msg
+todosView form =
     let
-        linkView i =
-            div
-                [ class "row link" ]
-                [ col' 3 [ text "Link" ]
-                , Input.textInput
-                    (Form.getFieldAsString ("links." ++ (toString i) ++ ".name") form)
-                    [ placeholder "Name" ]
-                , textGroup
-                    "URL"
-                    (Form.getFieldAsString ("links." ++ (toString i) ++ ".url") form)
-                , button [ onClick (Form.RemoveItem "links" i) ] [ text "Remove" ]
-                ]
+        allTodos =
+            List.concatMap (todoItemView form) (Form.getListIndexes "todos" form)
     in
         div
-            [ class "links" ]
-        <|
-            (List.map linkView (Form.getListIndexes "links" form))
-                ++ [ button [ onClick (Form.Append "links") ] [ text "Add link" ] ]
+            [ class "row" ]
+            [ col' 3
+                [ label [ class "control-label" ] [ text "Todolist" ]
+                , br [] []
+                , button [ onClick (Form.Append "todos"), class "btn btn-xs btn-default" ] [ text "Add" ]
+                ]
+            , col' 9
+                [ div [ class "todos" ] allTodos
+                ]
+            ]
+
+
+todoItemView : Form CustomError User -> Int -> List (Html Form.Msg)
+todoItemView form i =
+    let
+        labelField =
+            Form.getFieldAsString ("todos." ++ (toString i) ++ ".label") form
+    in
+        [ div
+            [ class ("input-group" ++ (errorClass labelField.liveError)) ]
+            [ span
+                [ class "input-group-addon" ]
+                [ Input.checkboxInput
+                    (Form.getFieldAsBool ("todos." ++ (toString i) ++ ".done") form)
+                    []
+                ]
+            , Input.textInput
+                labelField
+                [ class "form-control" ]
+            , span
+                [ class "input-group-btn" ]
+                [ button
+                    [ onClick (Form.RemoveItem "todos" i), class "btn btn-danger" ]
+                    [ text "Remove" ]
+                ]
+            ]
+        , br [] []
+        ]

--- a/example/src/View.elm
+++ b/example/src/View.elm
@@ -1,7 +1,6 @@
 module View exposing (..)
 
 import String
-import Html.App as Html
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -82,12 +81,12 @@ todosView form =
     in
         div
             [ class "row" ]
-            [ col' 3
+            [ colN 3
                 [ label [ class "control-label" ] [ text "Todolist" ]
                 , br [] []
                 , button [ onClick (Form.Append "todos"), class "btn btn-xs btn-default" ] [ text "Add" ]
                 ]
-            , col' 9
+            , colN 9
                 [ div [ class "todos" ] allTodos
                 ]
             ]

--- a/example/src/View/Bootstrap.elm
+++ b/example/src/View/Bootstrap.elm
@@ -19,15 +19,15 @@ col' i content =
 
 
 type alias GroupBuilder a =
-    String -> FieldState CustomError a -> Html Form.Msg
+    Html Form.Msg -> FieldState CustomError a -> Html Form.Msg
 
 
-formGroup : String -> Maybe (ErrorValue CustomError) -> List (Html Form.Msg) -> Html Form.Msg
+formGroup : Html Form.Msg -> Maybe (ErrorValue CustomError) -> List (Html Form.Msg) -> Html Form.Msg
 formGroup label' maybeError inputs =
     div
         [ class ("row form-group " ++ (errorClass maybeError)) ]
         [ col' 3
-            [ label [ class "control-label" ] [ text label' ] ]
+            [ label [ class "control-label" ] [ label' ] ]
         , col' 5
             inputs
         , col' 4
@@ -65,13 +65,13 @@ textAreaGroup label' state =
 
 checkboxGroup : GroupBuilder Bool
 checkboxGroup label' state =
-    formGroup ""
+    formGroup (text "")
         state.liveError
         [ div
             [ class "checkbox" ]
             [ label []
                 [ Input.checkboxInput state []
-                , text label'
+                , label'
                 ]
             ]
         ]

--- a/example/src/View/Bootstrap.elm
+++ b/example/src/View/Bootstrap.elm
@@ -13,8 +13,8 @@ row content =
     div [ class "row" ] content
 
 
-col' : Int -> List (Html Form.Msg) -> Html Form.Msg
-col' i content =
+colN : Int -> List (Html Form.Msg) -> Html Form.Msg
+colN i content =
     div [ class ("col-xs-" ++ toString i) ] content
 
 
@@ -23,14 +23,14 @@ type alias GroupBuilder a =
 
 
 formGroup : Html Form.Msg -> Maybe (ErrorValue CustomError) -> List (Html Form.Msg) -> Html Form.Msg
-formGroup label' maybeError inputs =
+formGroup label_ maybeError inputs =
     div
         [ class ("row form-group " ++ (errorClass maybeError)) ]
-        [ col' 3
-            [ label [ class "control-label" ] [ label' ] ]
-        , col' 5
+        [ colN 3
+            [ label [ class "control-label" ] [ label_ ] ]
+        , colN 5
             inputs
-        , col' 4
+        , colN 4
             [ errorMessage maybeError ]
         ]
 
@@ -42,8 +42,8 @@ formActions content =
 
 
 textGroup : GroupBuilder String
-textGroup label' state =
-    formGroup label'
+textGroup label_ state =
+    formGroup label_
         state.liveError
         [ Input.textInput state
             [ class "form-control"
@@ -53,8 +53,8 @@ textGroup label' state =
 
 
 textAreaGroup : GroupBuilder String
-textAreaGroup label' state =
-    formGroup label'
+textAreaGroup label_ state =
+    formGroup label_
         state.liveError
         [ Input.textArea state
             [ class "form-control"
@@ -64,28 +64,28 @@ textAreaGroup label' state =
 
 
 checkboxGroup : GroupBuilder Bool
-checkboxGroup label' state =
+checkboxGroup label_ state =
     formGroup (text "")
         state.liveError
         [ div
             [ class "checkbox" ]
             [ label []
                 [ Input.checkboxInput state []
-                , label'
+                , label_
                 ]
             ]
         ]
 
 
 selectGroup : List ( String, String ) -> GroupBuilder String
-selectGroup options label' state =
-    formGroup label'
+selectGroup options label_ state =
+    formGroup label_
         state.liveError
         [ Input.selectInput options state [ class "form-control" ] ]
 
 
 radioGroup : List ( String, String ) -> GroupBuilder String
-radioGroup options label' state =
+radioGroup options label_ state =
     let
         item ( v, l ) =
             label
@@ -94,7 +94,7 @@ radioGroup options label' state =
                 , text l
                 ]
     in
-        formGroup label'
+        formGroup label_
             state.liveError
             (List.map item options)
 

--- a/example/src/View/Bootstrap.elm
+++ b/example/src/View/Bootstrap.elm
@@ -4,7 +4,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Form exposing (Form, FieldState)
 import Form.Input as Input
-import Form.Error exposing (Error)
+import Form.Error exposing (Error, ErrorValue)
 import Model exposing (..)
 
 
@@ -22,7 +22,7 @@ type alias GroupBuilder a =
     String -> FieldState CustomError a -> Html Form.Msg
 
 
-formGroup : String -> Maybe (Error CustomError) -> List (Html Form.Msg) -> Html Form.Msg
+formGroup : String -> Maybe (ErrorValue CustomError) -> List (Html Form.Msg) -> Html Form.Msg
 formGroup label' maybeError inputs =
     div
         [ class ("row form-group " ++ (errorClass maybeError)) ]
@@ -104,7 +104,7 @@ errorClass maybeError =
     Maybe.map (\_ -> "has-error") maybeError |> Maybe.withDefault ""
 
 
-errorMessage : Maybe (Error CustomError) -> Html Form.Msg
+errorMessage : Maybe (ErrorValue CustomError) -> Html Form.Msg
 errorMessage maybeError =
     case maybeError of
         Just error ->

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "elm-simple-form",
+  "name": "elm-form",
   "version": "1.0.0",
   "description": "HTML live forms builders and validation for Elm.",
   "main": "index.js",
@@ -12,12 +12,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/etaque/elm-simple-form.git"
+    "url": "git+https://github.com/etaque/elm-form.git"
   },
   "author": "Emilien Taque",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/etaque/elm-simple-form/issues"
+    "url": "https://github.com/etaque/elm-form/issues"
   },
-  "homepage": "https://github.com/etaque/elm-simple-form#readme"
+  "homepage": "https://github.com/etaque/elm-form#readme"
 }

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -73,7 +73,7 @@ can be retrived with `Form.getFieldAsString` or `Form.getFieldAsBool`.
  * `value` - a `Maybe` of the requested type
  * `error` - a `Maybe` of the field error
  * `liveError` - same but with added logic for live validation
-    (see [`getLiveErrorAt`](https://github.com/etaque/elm-simple-form/blob/master/src/Form.elm) impl)
+    (see [`getLiveErrorAt`](https://github.com/etaque/elm-form/blob/master/src/Form.elm) impl)
  * `isDirty` - if the field content has been changed since last validation
  * `isChanged` - if the field value has changed since last init/reset
  * `hasFocus` - if the field is currently focused

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -53,7 +53,7 @@ initial : List ( String, Field ) -> Validation e output -> Form e output
 initial initialFields validation =
     let
         model =
-            { fields = Field.group initialFields
+            { fields = Tree.group initialFields
             , focus = Nothing
             , dirtyFields = Set.empty
             , changedFields = Set.empty
@@ -249,7 +249,7 @@ update msg (F model) =
             let
                 newModel =
                     { model
-                        | fields = Field.group fields
+                        | fields = Tree.group fields
                         , dirtyFields = Set.empty
                         , changedFields = Set.empty
                         , isSubmitted = False

--- a/src/Form/Error.elm
+++ b/src/Form/Error.elm
@@ -1,19 +1,23 @@
-module Form.Error exposing (Error(..), getAt)
+module Form.Error exposing (Error, ErrorValue(..), value)
 
 {-| Validation errors.
 
-@docs Error, getAt
+@docs Error, ErrorValue, value
 -}
 
-import Dict exposing (Dict)
+import Form.Tree as Tree exposing (Tree)
+
+
+{-| Tree of errors.
+-}
+type alias Error e =
+    Tree (ErrorValue e)
 
 
 {-| A validation error. See `Form.Validate.customError` for `CustomError` building.
 -}
-type Error e
-    = GroupErrors (Dict String (Error e))
-    | ListErrors (List (Error e))
-    | Empty
+type ErrorValue e
+    = Empty
     | InvalidString
     | InvalidEmail
     | InvalidUrl
@@ -32,13 +36,8 @@ type Error e
     | CustomError e
 
 
-{-| Get error at name, for nested errors.
+{-| Build a tree node (a leaf) for this error
 -}
-getAt : String -> Error e -> Maybe (Error e)
-getAt name error =
-    case error of
-        GroupErrors groupErrors ->
-            Dict.get name groupErrors
-
-        _ ->
-            Nothing
+value : ErrorValue a -> Error a
+value =
+    Tree.Value

--- a/src/Form/Error.elm
+++ b/src/Form/Error.elm
@@ -12,6 +12,7 @@ import Dict exposing (Dict)
 -}
 type Error e
     = GroupErrors (Dict String (Error e))
+    | ListErrors (List (Error e))
     | Empty
     | InvalidString
     | InvalidEmail

--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -1,9 +1,9 @@
-module Form.Field exposing (Field, FieldValue(..), field, group, list, listGroup, value, asString, asBool)
+module Form.Field exposing (Field, FieldValue(..), value, string, bool, group, list, asString, asBool)
 
 {-| Read and write field values.
 
 # Constructors
-@docs Field, FieldValue, field, group, list, listGroup, value
+@docs Field, FieldValue, value, string, bool, group, list
 
 
 # Value readers
@@ -22,40 +22,9 @@ type alias Field =
 {-| Form field. Can either be a group of named fields, or a final field.
 -}
 type FieldValue
-    = Text String
-    | Textarea String
-    | Select String
-    | Radio String
-    | Check Bool
+    = String String
+    | Bool Bool
     | EmptyField
-
-
-{-| Builds a tuple of field name and value, for groups.
--}
-field : String -> FieldValue -> ( String, Field )
-field name value =
-    ( name, Tree.Value value )
-
-
-{-| Build a group of values, for nested forms.
--}
-group : String -> List ( String, Field ) -> ( String, Field )
-group name pairs =
-    ( name, Tree.group pairs )
-
-
-{-| Build a list of values, for dynamic fields list
--}
-list : String -> List Field -> ( String, Field )
-list name items =
-    ( name, Tree.list items )
-
-
-{-| Group values without name, for lists
--}
-listGroup : List ( String, Field ) -> Field
-listGroup =
-    Tree.group
 
 
 {-| Build a field from its value.
@@ -65,12 +34,40 @@ value =
     Tree.Value
 
 
+{-| Build a string field, for text inputs, selects, etc.
+-}
+string : String -> Field
+string =
+    String >> Tree.Value
+
+
+{-| Build a boolean field, for checkboxes.
+-}
+bool : Bool -> Field
+bool =
+    Bool >> Tree.Value
+
+
+{-| Gather named fields as a group field.
+-}
+group : List ( String, Field ) -> Field
+group =
+    Tree.group
+
+
+{-| Gather fields as a list field.
+-}
+list : List Field -> Field
+list =
+    Tree.List
+
+
 {-| Get field value as boolean.
 -}
 asBool : Field -> Maybe Bool
-asBool node =
-    case node of
-        Tree.Value (Check b) ->
+asBool field =
+    case field of
+        Tree.Value (Bool b) ->
             Just b
 
         _ ->
@@ -82,22 +79,8 @@ asBool node =
 asString : Field -> Maybe String
 asString field =
     case field of
-        Tree.Value value ->
-            case value of
-                Text s ->
-                    Just s
-
-                Textarea s ->
-                    Just s
-
-                Select s ->
-                    Just s
-
-                Radio s ->
-                    Just s
-
-                _ ->
-                    Nothing
+        Tree.Value (String s) ->
+            Just s
 
         _ ->
             Nothing

--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -1,9 +1,9 @@
-module Form.Field exposing (Field, FieldValue(..), field, group, list, value, asString, asBool)
+module Form.Field exposing (Field, FieldValue(..), field, group, list, listGroup, value, asString, asBool)
 
 {-| Read and write field values.
 
 # Constructors
-@docs Field, FieldValue, field, group, list, value
+@docs Field, FieldValue, field, group, list, listGroup, value
 
 
 # Value readers
@@ -49,6 +49,13 @@ group name pairs =
 list : String -> List Field -> ( String, Field )
 list name items =
     ( name, Tree.list items )
+
+
+{-| Group values without name, for lists
+-}
+listGroup : List ( String, Field ) -> Field
+listGroup =
+    Tree.group
 
 
 {-| Build a field from its value.

--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -1,9 +1,9 @@
-module Form.Field exposing (Field(..), group, at, asString, asBool)
+module Form.Field exposing (Field(..), group, list, at, asString, asBool)
 
 {-| Read and write field values.
 
 # Constructors
-@docs Field, group
+@docs Field, group, list
 
 # Value readers
 @docs at, asString, asBool
@@ -21,6 +21,7 @@ type Field
     | Select String
     | Radio String
     | Check Bool
+    | List (List Field)
     | EmptyField
 
 
@@ -41,6 +42,25 @@ at name field =
 
         _ ->
             Nothing
+
+
+{-| Build a list of values, for dynamic fields list
+-}
+list : List Field -> Field
+list =
+    List
+
+
+{-| Get field as a list of fields
+-}
+asList : Field -> List Field
+asList field =
+    case field of
+        List items ->
+            items
+
+        _ ->
+            []
 
 
 {-| Get field value as boolean.

--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -1,9 +1,9 @@
-module Form.Field exposing (Field, FieldValue(..), group, list, value, asString, asBool)
+module Form.Field exposing (Field, FieldValue(..), field, group, list, value, asString, asBool)
 
 {-| Read and write field values.
 
 # Constructors
-@docs Field, FieldValue, group, list, value
+@docs Field, FieldValue, field, group, list, value
 
 
 # Value readers
@@ -30,18 +30,25 @@ type FieldValue
     | EmptyField
 
 
+{-| Builds a tuple of field name and value, for groups.
+-}
+field : String -> FieldValue -> ( String, Field )
+field name value =
+    ( name, Tree.Value value )
+
+
 {-| Build a group of values, for nested forms.
 -}
-group : List ( String, Field ) -> Field
-group =
-    Tree.group
+group : String -> List ( String, Field ) -> ( String, Field )
+group name pairs =
+    ( name, Tree.group pairs )
 
 
 {-| Build a list of values, for dynamic fields list
 -}
-list : List Field -> Field
-list =
-    Tree.list
+list : String -> List Field -> ( String, Field )
+list name items =
+    ( name, Tree.list items )
 
 
 {-| Build a field from its value.

--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -1,4 +1,4 @@
-module Form.Field exposing (Field(..), group, list, at, asString, asBool)
+module Form.Field exposing (Field(..), group, list, at, atIndex, asString, asBool, asList)
 
 {-| Read and write field values.
 
@@ -6,7 +6,7 @@ module Form.Field exposing (Field(..), group, list, at, asString, asBool)
 @docs Field, group, list
 
 # Value readers
-@docs at, asString, asBool
+@docs at, atIndex, asString, asBool, asList
 -}
 
 import Dict exposing (Dict)
@@ -42,6 +42,15 @@ at name field =
 
         _ ->
             Nothing
+
+
+{-| Get field at index, for list of fields.
+-}
+atIndex : Int -> Field -> Maybe Field
+atIndex index field =
+    asList field
+        |> List.drop index
+        |> List.head
 
 
 {-| Build a list of values, for dynamic fields list

--- a/src/Form/Init.elm
+++ b/src/Form/Init.elm
@@ -1,0 +1,36 @@
+module Form.Init exposing (setBool, setString, setGroup, setList)
+
+{-| Helpers for initial fields values
+
+@docs setBool, setString, setGroup, setList
+-}
+
+import Form.Field as Field exposing (Field, FieldValue)
+
+
+{-| Builds a tuple of field name and boolean value
+-}
+setBool : String -> Bool -> ( String, Field )
+setBool name b =
+    ( name, Field.bool b )
+
+
+{-| Builds a tuple of field name and string value
+-}
+setString : String -> String -> ( String, Field )
+setString name str =
+    ( name, Field.string str )
+
+
+{-| Build a group of values, for nested forms.
+-}
+setGroup : String -> List ( String, Field ) -> ( String, Field )
+setGroup name pairs =
+    ( name, Field.group pairs )
+
+
+{-| Build a list of values, for dynamic fields setList
+-}
+setList : String -> List Field -> ( String, Field )
+setList name items =
+    ( name, Field.list items )

--- a/src/Form/Input.elm
+++ b/src/Form/Input.elm
@@ -15,7 +15,7 @@ import Html.Events exposing (..)
 import Html.Attributes as HtmlAttr exposing (..)
 import Json.Decode as Json
 import Form exposing (Form, Msg, FieldState, Msg(Input, Focus, Blur))
-import Form.Field exposing (Field(..))
+import Form.Field exposing (Field, FieldValue(..))
 
 
 {-| An input renders Html from a field state and list of additional attributes.
@@ -25,19 +25,15 @@ type alias Input e a =
     FieldState e a -> List (Attribute Msg) -> Html Msg
 
 
-(?=) =
-    flip Maybe.withDefault
-
-
 {-| Untyped input, first param is `type` attribute.
 -}
-baseInput : String -> (String -> Field) -> Input e String
-baseInput t toField state attrs =
+baseInput : String -> (String -> FieldValue) -> Input e String
+baseInput t toFieldValue state attrs =
     let
         formAttrs =
             [ type' t
-            , defaultValue (state.value ?= "")
-            , onInput (toField >> (Input state.path))
+            , defaultValue (state.value |> Maybe.withDefault "")
+            , onInput (toFieldValue >> (Input state.path))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)
             ]
@@ -65,7 +61,11 @@ textArea : Input e String
 textArea state attrs =
     let
         formAttrs =
+<<<<<<< HEAD
             [ defaultValue (state.value ?= "")
+=======
+            [ value (state.value |> Maybe.withDefault "")
+>>>>>>> extracts tree structure and functions
             , onInput (Textarea >> (Input state.path))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)
@@ -100,7 +100,7 @@ checkboxInput state attrs =
     let
         formAttrs =
             [ type' "checkbox"
-            , checked (state.value ?= False)
+            , checked (state.value |> Maybe.withDefault False)
             , onCheck (Check >> (Input state.path))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)

--- a/src/Form/Input.elm
+++ b/src/Form/Input.elm
@@ -61,11 +61,7 @@ textArea : Input e String
 textArea state attrs =
     let
         formAttrs =
-<<<<<<< HEAD
-            [ defaultValue (state.value ?= "")
-=======
-            [ value (state.value |> Maybe.withDefault "")
->>>>>>> extracts tree structure and functions
+            [ defaultValue (state.value |> Maybe.withDefault "")
             , onInput (Textarea >> (Input state.path))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)

--- a/src/Form/Input.elm
+++ b/src/Form/Input.elm
@@ -14,8 +14,8 @@ import Html exposing (..)
 import Html.Events exposing (..)
 import Html.Attributes as HtmlAttr exposing (..)
 import Json.Decode as Json
-import Form exposing (Form, Msg, FieldState, Msg(Input, Focus, Blur))
-import Form.Field exposing (Field, FieldValue(..))
+import Form exposing (Form, Msg, FieldState, Msg(Input, Focus, Blur), InputType(..))
+import Form.Field as Field exposing (Field, FieldValue(..))
 
 
 {-| An input renders Html from a field state and list of additional attributes.
@@ -27,13 +27,13 @@ type alias Input e a =
 
 {-| Untyped input, first param is `type` attribute.
 -}
-baseInput : String -> (String -> FieldValue) -> Input e String
-baseInput t toFieldValue state attrs =
+baseInput : String -> (String -> FieldValue) -> InputType -> Input e String
+baseInput t toFieldValue inputType state attrs =
     let
         formAttrs =
-            [ type' t
+            [ type_ t
             , defaultValue (state.value |> Maybe.withDefault "")
-            , onInput (toFieldValue >> (Input state.path))
+            , onInput (toFieldValue >> (Input state.path inputType))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)
             ]
@@ -45,14 +45,14 @@ baseInput t toFieldValue state attrs =
 -}
 textInput : Input e String
 textInput =
-    baseInput "text" Text
+    baseInput "text" String Text
 
 
 {-| Password input.
 -}
 passwordInput : Input e String
 passwordInput =
-    baseInput "password" Text
+    baseInput "password" String Text
 
 
 {-| Textarea.
@@ -62,7 +62,7 @@ textArea state attrs =
     let
         formAttrs =
             [ defaultValue (state.value |> Maybe.withDefault "")
-            , onInput (Textarea >> (Input state.path))
+            , onInput (String >> (Input state.path Textarea))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)
             ]
@@ -78,7 +78,7 @@ selectInput options state attrs =
         formAttrs =
             [ on
                 "change"
-                (targetValue |> Json.map (Select >> (Input state.path)))
+                (targetValue |> Json.map (String >> (Input state.path Select)))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)
             ]
@@ -95,9 +95,9 @@ checkboxInput : Input e Bool
 checkboxInput state attrs =
     let
         formAttrs =
-            [ type' "checkbox"
+            [ type_ "checkbox"
             , checked (state.value |> Maybe.withDefault False)
-            , onCheck (Check >> (Input state.path))
+            , onCheck (Bool >> (Input state.path Checkbox))
             , onFocus (Focus state.path)
             , onBlur (Blur state.path)
             ]
@@ -111,7 +111,7 @@ radioInput : String -> Input e String
 radioInput value state attrs =
     let
         formAttrs =
-            [ type' "radio"
+            [ type_ "radio"
             , name state.path
             , HtmlAttr.value value
             , checked (state.value == Just value)
@@ -119,7 +119,7 @@ radioInput value state attrs =
             , onBlur (Blur state.path)
             , on
                 "change"
-                (targetValue |> Json.map (Radio >> (Input state.path)))
+                (targetValue |> Json.map (String >> (Input state.path Radio)))
             ]
     in
         input (formAttrs ++ attrs) []

--- a/src/Form/Tree.elm
+++ b/src/Form/Tree.elm
@@ -152,28 +152,26 @@ toFragment s =
 -}
 setAtPath : String -> Tree value -> Tree value -> Tree value
 setAtPath path node tree =
-    recursiveSet (extractFragments path) node (Just tree)
+    recursiveSet (extractFragments path) node tree
 
 
-recursiveSet : List Fragment -> Tree value -> Maybe (Tree value) -> Tree value
-recursiveSet fragments node maybeTree =
+recursiveSet : List Fragment -> Tree value -> Tree value -> Tree value
+recursiveSet fragments node tree =
     case fragments of
         head :: rest ->
             case head of
                 IntFragment index ->
-                    maybeTree
-                        |> Maybe.map asList
-                        |> Maybe.withDefault []
-                        |> updateListAtIndex index (\f -> recursiveSet rest node (Just f))
+                    asList tree
+                        |> updateListAtIndex index (recursiveSet rest node)
                         |> List
 
                 StringFragment name ->
                     let
-                        tree =
-                            Maybe.withDefault (Group Dict.empty) maybeTree
+                        target =
+                            getAtName name tree |> Maybe.withDefault (Group Dict.empty)
 
                         childNode =
-                            recursiveSet rest node (getAtName name tree)
+                            recursiveSet rest node target
                     in
                         merge (Group (Dict.fromList [ ( name, childNode ) ])) tree
 

--- a/src/Form/Tree.elm
+++ b/src/Form/Tree.elm
@@ -1,0 +1,202 @@
+module Form.Tree exposing (Tree(..), getAtPath, getAtName, getAtIndex, valuesWithPath, group, list, asList, asValue, setAtPath)
+
+{-| Data structures
+
+# Tree structure and builders
+@docs Tree, group, list
+
+# Readers
+@docs getAtPath, getAtName, getAtIndex, asList, asValue, valuesWithPath
+
+# Writers
+@docs setAtPath
+-}
+
+import Dict exposing (Dict)
+import String
+
+
+{-| Field values and errors are stored as trees.
+-}
+type Tree value
+    = Group (Dict String (Tree value))
+    | List (List (Tree value))
+    | Value value
+
+
+type Fragment
+    = StringFragment String
+    | IntFragment Int
+
+
+{-| Get node at given path
+-}
+getAtPath : String -> Tree value -> Maybe (Tree value)
+getAtPath path tree =
+    let
+        walkPath fragment maybeField =
+            case fragment of
+                IntFragment index ->
+                    maybeField `Maybe.andThen` getAtIndex index
+
+                StringFragment name ->
+                    maybeField `Maybe.andThen` getAtName name
+    in
+        List.foldl walkPath (Just tree) (extractFragments path)
+
+
+{-| Get node at name, if group
+-}
+getAtName : String -> Tree value -> Maybe (Tree value)
+getAtName name value =
+    case value of
+        Group group ->
+            Dict.get name group
+
+        _ ->
+            Nothing
+
+
+{-| Get node at index, if list of nodes.
+-}
+getAtIndex : Int -> Tree value -> Maybe (Tree value)
+getAtIndex index value =
+    asList value
+        |> List.drop index
+        |> List.head
+
+
+{-| Get list of errors on qualified paths.
+-}
+valuesWithPath : Tree value -> List ( String, value )
+valuesWithPath tree =
+    let
+        mapGroupItem path ( name, error ) =
+            walkTree (path ++ [ name ]) error
+
+        walkTree path value =
+            case value of
+                Group group ->
+                    List.concatMap
+                        (mapGroupItem path)
+                        (Dict.toList group)
+
+                List items ->
+                    List.concatMap
+                        (mapGroupItem path)
+                        (List.indexedMap (\index item -> ( toString index, item )) items)
+
+                Value value ->
+                    [ ( String.join "." path, value ) ]
+    in
+        walkTree [] tree
+
+
+{-| Extract value, if possible.
+-}
+asValue : Tree value -> Maybe value
+asValue node =
+    case node of
+        Value value ->
+            Just value
+
+        _ ->
+            Nothing
+
+
+{-| Get field as a list of fields
+-}
+asList : Tree value -> List (Tree value)
+asList value =
+    case value of
+        List items ->
+            items
+
+        _ ->
+            []
+
+
+{-| Helper to create a group value.
+-}
+group : List ( String, Tree value ) -> Tree value
+group items =
+    items
+        |> Dict.fromList
+        |> Group
+
+
+{-| Build a list of values, for dynamic fields list
+-}
+list : List (Tree value) -> Tree value
+list =
+    List
+
+
+extractFragments : String -> List Fragment
+extractFragments name =
+    String.split "." name
+        |> List.map toFragment
+
+
+toFragment : String -> Fragment
+toFragment s =
+    case String.toInt s of
+        Ok i ->
+            IntFragment i
+
+        Err _ ->
+            StringFragment s
+
+
+{-| Set node in tree at given path.
+-}
+setAtPath : String -> Tree value -> Tree value -> Tree value
+setAtPath path node tree =
+    recursiveSet (extractFragments path) node (Just tree)
+
+
+recursiveSet : List Fragment -> Tree value -> Maybe (Tree value) -> Tree value
+recursiveSet fragments node maybeTree =
+    case fragments of
+        head :: rest ->
+            case head of
+                IntFragment index ->
+                    maybeTree
+                        |> Maybe.map asList
+                        |> Maybe.withDefault []
+                        |> updateListAtIndex index (\f -> recursiveSet rest node (Just f))
+                        |> List
+
+                StringFragment name ->
+                    let
+                        tree =
+                            Maybe.withDefault (Group Dict.empty) maybeTree
+
+                        childNode =
+                            recursiveSet rest node (getAtName name tree)
+                    in
+                        merge (Group (Dict.fromList [ ( name, childNode ) ])) tree
+
+        [] ->
+            node
+
+
+updateListAtIndex : Int -> (a -> a) -> List a -> List a
+updateListAtIndex index updater =
+    List.indexedMap
+        (\i f ->
+            if i == index then
+                updater f
+            else
+                f
+        )
+
+
+merge : Tree value -> Tree value -> Tree value
+merge t1 t2 =
+    case ( t1, t2 ) of
+        ( Group g1, Group g2 ) ->
+            Group (Dict.union g1 g2)
+
+        _ ->
+            t1

--- a/src/Form/Tree.elm
+++ b/src/Form/Tree.elm
@@ -1,9 +1,9 @@
-module Form.Tree exposing (Tree(..), getAtPath, getAtName, getAtIndex, valuesWithPath, group, list, asList, asValue, setAtPath)
+module Form.Tree exposing (Tree(..), getAtPath, getAtName, getAtIndex, valuesWithPath, group, asList, asValue, setAtPath)
 
 {-| Data structures
 
 # Tree structure and builders
-@docs Tree, group, list
+@docs Tree, group
 
 # Readers
 @docs getAtPath, getAtName, getAtIndex, asList, asValue, valuesWithPath
@@ -37,10 +37,10 @@ getAtPath path tree =
         walkPath fragment maybeField =
             case fragment of
                 IntFragment index ->
-                    maybeField `Maybe.andThen` getAtIndex index
+                    maybeField |> Maybe.andThen (getAtIndex index)
 
                 StringFragment name ->
-                    maybeField `Maybe.andThen` getAtName name
+                    maybeField |> Maybe.andThen (getAtName name)
     in
         List.foldl walkPath (Just tree) (extractFragments path)
 
@@ -123,13 +123,6 @@ group items =
     items
         |> Dict.fromList
         |> Group
-
-
-{-| Build a list of values, for dynamic fields list
--}
-list : List (Tree value) -> Tree value
-list =
-    List
 
 
 extractFragments : String -> List Fragment

--- a/src/Form/Validate.elm
+++ b/src/Form/Validate.elm
@@ -467,3 +467,23 @@ oneOf validations field =
                     result
     in
         List.foldl walkResults (Err Empty) results
+
+
+list : Validation e a -> Validation e (List a)
+list validation field =
+    case field of
+        List items ->
+            let
+                results =
+                    List.map validation items
+
+                errors =
+                    List.filterMap getErr results
+            in
+                if List.isEmpty errors then
+                    Ok (List.filterMap Result.toMaybe results)
+                else
+                    Err (ListErrors errors)
+
+        _ ->
+            Err Empty

--- a/src/Form/Validate.elm
+++ b/src/Form/Validate.elm
@@ -1,4 +1,4 @@
-module Form.Validate exposing (Validation, get, map, andThen, pipeTo, apply, customError, defaultValue, formatError, withCustomError, form1, form2, form3, form4, form5, form6, form7, form8, string, int, float, bool, date, maybe, email, url, emptyString, minInt, maxInt, minFloat, maxFloat, minLength, maxLength, nonEmpty, format, includedIn, fail, succeed, customValidation, oneOf)
+module Form.Validate exposing (Validation, get, map, andThen, pipeTo, apply, customError, defaultValue, formatError, withCustomError, form1, form2, form3, form4, form5, form6, form7, form8, list, string, int, float, bool, date, maybe, email, url, emptyString, minInt, maxInt, minFloat, maxFloat, minLength, maxLength, nonEmpty, format, includedIn, fail, succeed, customValidation, oneOf)
 
 {-| Form validation.
 
@@ -9,7 +9,7 @@ module Form.Validate exposing (Validation, get, map, andThen, pipeTo, apply, cus
 @docs form1, form2, form3, form4, form5, form6, form7, form8
 
 # Type extractors
-@docs string, int, float, bool, date, maybe, email, url, emptyString
+@docs list, string, int, float, bool, date, maybe, email, url, emptyString
 
 # Common filters
 @docs minInt, maxInt, minFloat, maxFloat, minLength, maxLength, nonEmpty, format, includedIn
@@ -469,6 +469,8 @@ oneOf validations field =
         List.foldl walkResults (Err Empty) results
 
 
+{-| Validate a list of fields.
+-}
 list : Validation e a -> Validation e (List a)
 list validation field =
     case field of
@@ -486,4 +488,4 @@ list validation field =
                     Err (ListErrors errors)
 
         _ ->
-            Err Empty
+            Ok []

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -5,7 +5,6 @@ import Test.Runner.Node exposing (run)
 import Json.Encode exposing (Value)
 
 
-main : Program Value
 main =
     run emit Tests.all
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -2,9 +2,7 @@ module Tests exposing (..)
 
 import Test exposing (..)
 import Expect exposing (..)
-import String
 import Model
-import Update
 import Form exposing (Form)
 import Form.Error exposing (..)
 import Form.Field as Field
@@ -33,7 +31,7 @@ all =
                         Form.update (Form.Append "links") initialForm
 
                     formAfterInput =
-                        Form.update (Form.Input name (Field.Text value)) formAfterAppend
+                        Form.update (Form.Input name Form.Text (Field.String value)) formAfterAppend
 
                     maybeState =
                         Form.getFieldAsString name formAfterInput

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -7,22 +7,36 @@ import Model
 import Update
 import Form exposing (Form)
 import Form.Error exposing (..)
+import Form.Field as Field
 
 
 all : Test
 all =
     describe "Initial example validation"
         [ test "has no output" <|
-            \_ -> equal (Form.getOutput validatedForm) Nothing
+            \_ -> equal Nothing (Form.getOutput validatedForm)
         , test "has errors on expected fields" <|
             \_ ->
                 equal
+                    (Form.getErrors validatedForm)
                     [ ( "email", InvalidString )
                     , ( "profile.age", InvalidInt )
                     , ( "profile.role", InvalidString )
                     , ( "profile.superpower", InvalidString )
                     ]
-                    (Form.getErrors validatedForm)
+        , test "set then get field in list" <|
+            \_ ->
+                let
+                    ( name, value ) =
+                        ( "links.0.name", "Twitter" )
+
+                    newForm =
+                        Form.update (Form.Input name (Field.Text value)) initialForm
+
+                    maybeState =
+                        Form.getFieldAsString name newForm
+                in
+                    equal (Just value) maybeState.value
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -24,17 +24,20 @@ all =
                     , ( "profile.role", InvalidString )
                     , ( "profile.superpower", InvalidString )
                     ]
-        , test "set then get field in list" <|
+        , test "append, set then get field in list" <|
             \_ ->
                 let
                     ( name, value ) =
                         ( "links.0.name", "Twitter" )
 
-                    newForm =
-                        Form.update (Form.Input name (Field.Text value)) initialForm
+                    formAfterAppend =
+                        Form.update (Form.Append "links") initialForm
+
+                    formAfterInput =
+                        Form.update (Form.Input name (Field.Text value)) formAfterAppend
 
                     maybeState =
-                        Form.getFieldAsString name newForm
+                        Form.getFieldAsString name formAfterInput
                 in
                     equal (Just value) maybeState.value
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -20,7 +20,6 @@ all =
                 equal
                     (Form.getErrors validatedForm)
                     [ ( "email", InvalidString )
-                    , ( "profile.age", InvalidInt )
                     , ( "profile.role", InvalidString )
                     , ( "profile.superpower", InvalidString )
                     ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -10,10 +10,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0"
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
This PR implements support for dynamic list of fields, as requested in #50 

This required a more powerful tree structure so its representation and handling have been extracted to a dedicated module. A few things have changed in the API, that will be a major release.
- Previously exposed types `Field.Field` and `Error.Error` have been renamed to `Field.FieldValue` and `Error.ErrorValue`
- `Field` and `Error` are now just trees of values and can be handled by `Tree` module if needed.
- in validation, errors must now be wrapped by `Error.value` 
- for initial fields values, helpers in `Field` module are now producing tuples
- list items must be operated with `Append` and `Remove` messages
- input on list item is adressed by index, ie `someGroup.0.someField`

/cc @amitaibu @DavidHernandez
