### PR TITLE
Add ResetSubmitted message

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "summary": "Live validation of form inputs in Elm",
     "repository": "https://github.com/etaque/elm-form.git",
     "license": "BSD3",

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -140,6 +140,7 @@ type Msg
     | Submit
     | Validate
     | Reset (List ( String, Field ))
+    | ResetSubmitted
 
 
 {-| Input types to determine live validation behaviour.
@@ -266,6 +267,13 @@ update msg (F model) =
                     }
             in
                 F (updateValidate newModel)
+
+        ResetSubmitted ->
+            let
+                validatedModel =
+                    updateValidate model
+            in
+                F { validatedModel | isSubmitted = False }
 
 
 updateValidate : Model e o -> Model e o


### PR DESCRIPTION
I've added a `ResetSubmitted` `Msg` so you can quickly reset the `isSubmitted` state.

## Why?

I'm working on a project that has both local and server validations, and after I've received an error from the server I want to reset the `isSubmitted` state of my form. Without this I would need to reset the whole form with fields and everything.

## Thoughts?

It's the first time I'm using this library, so, am I approaching this problem incorrectly?