### PR TITLE
Add 'sequence' function for validations

### DIFF
--- a/src/Form/Validate.elm
+++ b/src/Form/Validate.elm
@@ -1,9 +1,9 @@
-module Form.Validate exposing (Validation, field, map, andThen, andMap, customError, defaultValue, mapError, withCustomError, map2, map3, map4, map5, map6, map7, map8, list, string, int, float, bool, date, maybe, email, url, emptyString, minInt, maxInt, minFloat, maxFloat, minLength, maxLength, nonEmpty, format, includedIn, fail, succeed, customValidation, oneOf)
+module Form.Validate exposing (Validation, field, map, andThen, andMap, customError, defaultValue, mapError, withCustomError, map2, map3, map4, map5, map6, map7, map8, list, string, int, float, bool, date, maybe, email, url, emptyString, minInt, maxInt, minFloat, maxFloat, minLength, maxLength, nonEmpty, format, includedIn, fail, succeed, customValidation, oneOf, sequence)
 
 {-| Form validation.
 
 # Combinators
-@docs Validation, field, map, succeed, andThen, andMap, customError, defaultValue, mapError, withCustomError
+@docs Validation, field, map, succeed, andThen, andMap, customError, defaultValue, mapError, withCustomError, sequence
 
 # Fixed-size forms
 @docs map2, map3, map4, map5, map6, map7, map8
@@ -463,6 +463,14 @@ oneOf validations field =
                     result
     in
         List.foldl walkResults (Err (Error.value Empty)) results
+
+
+{-| Combine a list of validations into a validation producing a list of all
+results.
+-}
+sequence : List (Validation e a) -> Validation e (List a)
+sequence validations =
+    List.foldr (map2 (::)) (succeed []) validations
 
 
 {-| Validate a list of fields.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,51 +1,13 @@
 module Tests exposing (..)
 
 import Test exposing (..)
-import Expect exposing (..)
-import Model
-import Form exposing (Form)
-import Form.Error exposing (..)
-import Form.Field as Field
+import Tests.Example
+import Tests.Validate
 
 
 all : Test
 all =
-    describe "Initial example validation"
-        [ test "has no output" <|
-            \_ -> equal Nothing (Form.getOutput validatedForm)
-        , test "has errors on expected fields" <|
-            \_ ->
-                equal
-                    (Form.getErrors validatedForm)
-                    [ ( "date", InvalidDate )
-                    , ( "email", InvalidString )
-                    , ( "profile.role", InvalidString )
-                    , ( "profile.superpower", InvalidString )
-                    ]
-        , test "append, set then get field in list" <|
-            \_ ->
-                let
-                    ( name, value ) =
-                        ( "links.0.name", "Twitter" )
-
-                    formAfterAppend =
-                        Form.update Model.validate (Form.Append "links") initialForm
-
-                    formAfterInput =
-                        Form.update Model.validate (Form.Input name Form.Text (Field.String value)) formAfterAppend
-
-                    maybeState =
-                        Form.getFieldAsString name formAfterInput
-                in
-                    equal (Just value) maybeState.value
+    describe "elm-form Suite"
+        [ Tests.Example.all
+        , Tests.Validate.all
         ]
-
-
-initialForm : Form Model.CustomError Model.User
-initialForm =
-    Form.initial Model.initialFields Model.validate
-
-
-validatedForm : Form Model.CustomError Model.User
-validatedForm =
-    Form.update Model.validate Form.Validate initialForm

--- a/tests/Tests/Example.elm
+++ b/tests/Tests/Example.elm
@@ -1,0 +1,51 @@
+module Tests.Example exposing (all)
+
+import Test exposing (..)
+import Expect exposing (..)
+import Model
+import Form exposing (Form)
+import Form.Error exposing (..)
+import Form.Field as Field
+
+
+all : Test
+all =
+    describe "Initial example validation"
+        [ test "has no output" <|
+            \_ -> equal Nothing (Form.getOutput validatedForm)
+        , test "has errors on expected fields" <|
+            \_ ->
+                equal
+                    (Form.getErrors validatedForm)
+                    [ ( "date", InvalidDate )
+                    , ( "email", InvalidString )
+                    , ( "profile.role", InvalidString )
+                    , ( "profile.superpower", InvalidString )
+                    ]
+        , test "append, set then get field in list" <|
+            \_ ->
+                let
+                    ( name, value ) =
+                        ( "links.0.name", "Twitter" )
+
+                    formAfterAppend =
+                        Form.update Model.validate (Form.Append "links") initialForm
+
+                    formAfterInput =
+                        Form.update Model.validate (Form.Input name Form.Text (Field.String value)) formAfterAppend
+
+                    maybeState =
+                        Form.getFieldAsString name formAfterInput
+                in
+                    equal (Just value) maybeState.value
+        ]
+
+
+initialForm : Form Model.CustomError Model.User
+initialForm =
+    Form.initial Model.initialFields Model.validate
+
+
+validatedForm : Form Model.CustomError Model.User
+validatedForm =
+    Form.update Model.validate Form.Validate initialForm

--- a/tests/Tests/Validate.elm
+++ b/tests/Tests/Validate.elm
@@ -1,0 +1,52 @@
+module Tests.Validate exposing (all)
+
+import Test exposing (..)
+import Expect exposing (..)
+import Fuzz exposing (..)
+import Form.Validate as Validate exposing (Validation)
+import Form.Field
+import Form.Error
+import Form.Tree as Tree
+
+
+all : Test
+all =
+    describe "Validate"
+        [ fuzz (list int) "Transforms a list of successes to a success of lists" <|
+            \nums ->
+                nums
+                    |> List.map Validate.succeed
+                    |> Validate.sequence
+                    |> run
+                    |> Expect.equal (Ok nums)
+        , fuzz3 (list string) string string "Transforms a list with successes and failures into a failure list" <|
+            \strings firstErr secondErr ->
+                let
+                    successes =
+                        List.map
+                            (\str -> Validate.succeed str |> Validate.field str)
+                            strings
+
+                    failure str =
+                        Validate.fail (Validate.customError str)
+                            |> Validate.field str
+
+                    validations =
+                        successes ++ ((failure firstErr :: successes) ++ (failure secondErr :: successes))
+                in
+                    validations
+                        |> Validate.sequence
+                        |> run
+                        |> Expect.equal
+                            (Tree.group
+                                [ ( firstErr, Validate.customError firstErr )
+                                , ( secondErr, Validate.customError secondErr )
+                                ]
+                                |> Err
+                            )
+        ]
+
+
+run : Validation e a -> Result (Form.Error.Error e) a
+run validation =
+    Form.Field.group [] |> validation


### PR DESCRIPTION
This implements sequencing of validations, `List (Validation e a) -> Validation e (List a)`.

The name _sequence_ is in accordance with the [generic operation on monads](http://hackage.haskell.org/package/base-4.9.1.0/docs/Prelude.html#v:sequence), but also with [`Task.sequence` from the standard library](http://package.elm-lang.org/packages/elm-lang/core/5.0.0/Task#sequence).

I added basic fuzz tests and reorganized tests slightly so that they can be separated by modules.

Thanks for your library!