### PR TITLE
Fix list validation - Address #87

### DIFF
--- a/src/Form/Validate.elm
+++ b/src/Form/Validate.elm
@@ -483,13 +483,23 @@ list validation field =
                 results =
                     List.map validation items
 
+                indexedErrMaybe index res =
+                    case res of
+                        Ok _ ->
+                            Nothing
+
+                        Err e ->
+                            Just ( toString index, e )
+
                 errors =
-                    List.filterMap errMaybe results
+                    results
+                        |> List.indexedMap indexedErrMaybe
+                        |> List.filterMap identity
             in
                 if List.isEmpty errors then
                     Ok (List.filterMap Result.toMaybe results)
                 else
-                    Err (Tree.List errors)
+                    Err (Tree.group errors)
 
         _ ->
             Ok []

--- a/tests/Tests/Validate.elm
+++ b/tests/Tests/Validate.elm
@@ -4,9 +4,10 @@ import Test exposing (..)
 import Expect exposing (..)
 import Fuzz exposing (..)
 import Form.Validate as Validate exposing (Validation)
-import Form.Field
-import Form.Error
+import Form.Field as Field
+import Form.Error as Error
 import Form.Tree as Tree
+import Form
 
 
 all : Test
@@ -44,9 +45,24 @@ all =
                                 ]
                                 |> Err
                             )
+        , test "Puts the errors at the correct indexes" <|
+            \_ ->
+                let
+                    validate =
+                        Validate.field "field_name"
+                            (Validate.list
+                                (Validate.string |> Validate.andThen (Validate.minLength 4))
+                            )
+
+                    initialForm =
+                        Form.initial [ ( "field_name", Field.list [ (Field.value (Field.String "longer")), (Field.value (Field.String "not")), (Field.value (Field.String "longer")) ] ) ] validate
+                in
+                    Expect.equal
+                        [ ( "field_name.1", Error.ShorterStringThan 4 ) ]
+                        (Form.getErrors initialForm)
         ]
 
 
-run : Validation e a -> Result (Form.Error.Error e) a
+run : Validation e a -> Result (Error.Error e) a
 run validation =
-    Form.Field.group [] |> validation
+    Field.group [] |> validation


### PR DESCRIPTION
I wanted to find a fix that would keep the interface the same so it could be a patch version change. Moving `Error` into the same tree seemed to be a much larger task and would break the interface.