### PR TITLE
Fix getAtIndex for errors in a list

### DIFF
--- a/src/Form.elm
+++ b/src/Form.elm
@@ -241,7 +241,7 @@ update validation msg (F model) =
                         | fields = setFieldAt listName (Tree.List newListFields) model
                     }
             in
-                F newModel
+                F (updateValidate validation newModel)
 
         Submit ->
             let

--- a/src/Form/Tree.elm
+++ b/src/Form/Tree.elm
@@ -61,9 +61,17 @@ getAtName name value =
 -}
 getAtIndex : Int -> Tree value -> Maybe (Tree value)
 getAtIndex index value =
-    asList value
-        |> List.drop index
-        |> List.head
+    case value of
+        List items ->
+            items
+                |> List.drop index
+                |> List.head
+
+        Group group ->
+            Dict.get (toString index) group
+
+        Value _ ->
+            Nothing
 
 
 {-| Get list of errors on qualified paths.

--- a/tests/Tests/Validate.elm
+++ b/tests/Tests/Validate.elm
@@ -105,6 +105,51 @@ all =
                     Expect.equal
                         expectedField
                         (Form.getFieldAsString "a.1.b.0" updatedForm)
+        , test "Errors stay matched-up when an item is removed" <|
+            \_ ->
+                let
+                    validate =
+                        Validate.field "a"
+                            (Validate.list
+                                (Validate.field "b"
+                                    (Validate.list
+                                        (Validate.string |> Validate.andThen (Validate.minLength 4))
+                                    )
+                                )
+                            )
+
+                    initialForm =
+                        Form.initial
+                            [ ( "a"
+                              , Field.list
+                                    [ Field.group [ ( "b", Field.list [ Field.value (Field.String "init") ] ) ]
+                                    , Field.group [ ( "b", Field.list [ Field.value (Field.String "init") ] ) ]
+                                    , Field.group [ ( "b", Field.list [ Field.value (Field.String "init") ] ) ]
+                                    ]
+                              )
+                            ]
+                            validate
+
+                    updatedForm =
+                        initialForm
+                            |> Form.update validate (Form.Input "a.0.b.0" Form.Text (Field.String "longer"))
+                            |> Form.update validate (Form.Input "a.1.b.0" Form.Text (Field.String "not"))
+                            |> Form.update validate (Form.Input "a.2.b.0" Form.Text (Field.String "longer"))
+                            |> Form.update validate (Form.RemoveItem "a" 1)
+
+                    expectedField =
+                        { path = "a.1.b.0"
+                        , value = Just "longer"
+                        , error = Nothing
+                        , liveError = Nothing
+                        , isDirty = True
+                        , isChanged = True
+                        , hasFocus = False
+                        }
+                in
+                    Expect.equal
+                        expectedField
+                        (Form.getFieldAsString "a.1.b.0" updatedForm)
         ]
 
 

--- a/tests/Tests/Validate.elm
+++ b/tests/Tests/Validate.elm
@@ -65,33 +65,46 @@ all =
             \_ ->
                 let
                     validate =
-                        Validate.field "field_name"
+                        Validate.field "a"
                             (Validate.list
-                                (Validate.string |> Validate.andThen (Validate.minLength 4))
+                                (Validate.field "b"
+                                    (Validate.list
+                                        (Validate.string |> Validate.andThen (Validate.minLength 4))
+                                    )
+                                )
                             )
 
                     initialForm =
-                        Form.initial [ ( "field_name", Field.list [ (Field.value (Field.String "longer")), (Field.value (Field.String "not")), (Field.value (Field.String "longer")) ] ) ] validate
+                        Form.initial
+                            [ ( "a"
+                              , Field.list
+                                    [ Field.group [ ( "b", Field.list [ Field.value (Field.String "init") ] ) ]
+                                    , Field.group [ ( "b", Field.list [ Field.value (Field.String "init") ] ) ]
+                                    , Field.group [ ( "b", Field.list [ Field.value (Field.String "init") ] ) ]
+                                    ]
+                              )
+                            ]
+                            validate
 
                     updatedForm =
                         initialForm
-                            |> Form.update validate (Form.Input "field_name.0" Form.Text (Field.String "longer"))
-                            |> Form.update validate (Form.Input "field_name.1" Form.Text (Field.String "not"))
-                            |> Form.update validate (Form.Input "field_name.2" Form.Text (Field.String "longer"))
+                            |> Form.update validate (Form.Input "a.0.b.0" Form.Text (Field.String "longer"))
+                            |> Form.update validate (Form.Input "a.1.b.0" Form.Text (Field.String "not"))
+                            |> Form.update validate (Form.Input "a.2.b.0" Form.Text (Field.String "longer"))
 
                     expectedField =
-                        { path = "field_name.1"
+                        { path = "a.1.b.0"
                         , value = Just "not"
                         , error = Just (Error.ShorterStringThan 4)
                         , liveError = Nothing
-                        , isDirty = False
-                        , isChanged = False
+                        , isDirty = True
+                        , isChanged = True
                         , hasFocus = False
                         }
                 in
                     Expect.equal
                         expectedField
-                        (Form.getFieldAsString "field_name.1" initialForm)
+                        (Form.getFieldAsString "a.1.b.0" updatedForm)
         ]
 
 


### PR DESCRIPTION
I noticed that there's a difference between how `Form.getErrors` and `Form.getFieldAsString` traverse the tree. The change for the list validation caused a bug with the latter method because it would see the `0` in the fragment and could not handle the Tree being a dict instead of a list. I know this could also be an issue with `setAtIndex`, but that situation will likely not arise (and is not caused by my earlier PR). I've attempted to identify other areas affected by my earlier change and create more tests. It could probably still use a good look to check for areas I may have not known about. I've also pulled it into my app to ensure that it acts as expected. I am willing to look into working more on functions like `setAtIndex`, but I wanted to fix this bug first.