### PR TITLE
Fix dead links in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [complete example here](http://etaque.github.io/elm-form/example/) ([source 
 
 ## Basic usage
 
-See the [example validation test suite](https://github.com/etaque/elm-form/blob/master/example/tests/ValidationTests.elm)
+See the [example validation test suite](https://github.com/etaque/elm-form/blob/master/tests/ValidationTests.elm)
 and [test helper function docs](http://package.elm-lang.org/packages/etaque/elm-form/latest/Form-Test)
 for how to test-drive validations.
 

--- a/src/Form/Test.elm
+++ b/src/Form/Test.elm
@@ -1,7 +1,7 @@
 module Form.Test exposing (describeValidation, testValidation)
 
 {-| Helpers to test your validations. See
-[an example validation test suite here](https://github.com/etaque/elm-form/tree/master/example/tests).
+[an example validation test suite here](https://github.com/etaque/elm-form/tree/master/tests).
 
 @docs describeValidation, testValidation
 


### PR DESCRIPTION
Please accept this PR fixing two links in the readme and module documentation.